### PR TITLE
Bugfix/Remove double helo SMTP request, #97

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ defaults: &defaults
   docker:
     - image: circleci/ruby:2.5.0-node
   environment:
-    CC_TEST_REPORTER_ID: a98d23d6d916932ae11dbe5df36dee070173cbe376b68758901dcc289e098979
+    CC_TEST_REPORTER_ID: 693272a1328521f6f7c09d7ffd419b21c00410da26e98e94c687fdd38b26e2cb
 
 references:
   restore_bundle_cache: &restore_bundle_cache

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,9 +3,9 @@
 ### New Issue Checklist
 
 - [ ] I have updated truemail to the latest version
-- [ ] I have read the [Contribution Guidelines](https://github.com/rubygarage/truemail/blob/master/CONTRIBUTING.md)
+- [ ] I have read the [Contribution Guidelines](https://github.com/truemail-rb/truemail/blob/master/CONTRIBUTING.md)
 - [ ] I have read the [documentation](https://truemail-rb.org/truemail-gem)
-- [ ] I have searched for [existing GitHub issues](https://github.com/rubygarage/truemail/issues)
+- [ ] I have searched for [existing GitHub issues](https://github.com/truemail-rb/truemail/issues)
 
 ### Issue Description
 <!-- Please include what's happening, expected behavior, and any relevant code samples -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,7 @@
 - [ ] My code follows the code style of this project
 - [ ] My change requires a change to the documentation
 - [ ] I have updated the documentation accordingly
-- [ ] I have read the [**CONTRIBUTING** document](https://github.com/rubygarage/truemail/blob/master/CONTRIBUTING.md)
+- [ ] I have read the [**CONTRIBUTING** document](https://github.com/truemail-rb/truemail/blob/master/CONTRIBUTING.md)
 - [ ] I have added tests to cover my changes
 - [ ] I have run `bundle exec rspec` from the root directory to see all new and existing tests pass
 - [ ] I have run `rubocop` and `reek` to ensure the code style is valid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2020.10.19
+
+### Fixed
+
+SMTP connection errors: invalid `HELO` hostname (`localhost`), duplicate `HELO` (`verifier domain`).
+
+### Changed
+
+- Updated `Truemail::Validate::Smtp::Request#run`
+- Updated `Truemail::Validate::Smtp::Request#session_data`
+- Updated `Truemail::Validate::Smtp::Response`
+
+Now `helo` is a `Boolean` instead of `Net::SMTP::Response` instance. It was changed because `helo` is sending during SMTP-session initializing (`Net::SMTP.new.start`), and `helo` is always `true` if session up is okay. Also `hello` response won't logged as error if it happens. Example of `Truemail::Validate::Smtp::Response` instance from 1.9.3 version.
+
+```ruby
+#<struct Truemail::Validate::Smtp::Response:0x00007fa74704cd10
+  port_opened=true,
+  connection=true,
+  helo=true, # Returns Boolean instead of Net::SMTP::Response instance
+  mailfrom=false,
+  rcptto=nil,
+  errors={:mailfrom=>"server response timeout"}>
+```
+
 ## [1.9.2] - 2020.10.02
 
 ### Added
@@ -380,7 +404,7 @@ Truemail.validate('email@domain.com', with: :regex)
 
 ### Added
 
-- Configurable default validation type, [issue details](https://github.com/rubygarage/truemail/issues/48)
+- Configurable default validation type, [issue details](https://github.com/truemail-rb/truemail/issues/48)
 
 You can predefine default validation type for ```Truemail.validate('email@email.com')``` call without with-parameter. Available validation types: ```:regex```, ```:mx```, ```:smtp```. By default validation type still remains ```:smtp```
 
@@ -498,7 +522,7 @@ Truemail.configuration.validation_type_for = { 'somedomain.com' => :skip }
 
 ### Added
 
-- SMTP error body configurable option, [issue details](https://github.com/rubygarage/truemail/issues/19)
+- SMTP error body configurable option, [issue details](https://github.com/truemail-rb/truemail/issues/19)
 
 ### Changed
 
@@ -515,11 +539,11 @@ Truemail.configuration.validation_type_for = { 'somedomain.com' => :skip }
 
 ### Added
 
-- Reverse trace, [issue details](https://github.com/rubygarage/truemail/issues/18)
+- Reverse trace, [issue details](https://github.com/truemail-rb/truemail/issues/18)
 
 ### Fixed
 
-- Behaviour of current host address resolver, [issue details](https://github.com/rubygarage/truemail/issues/18)
+- Behaviour of current host address resolver, [issue details](https://github.com/truemail-rb/truemail/issues/18)
 
 ### Changed
 
@@ -530,7 +554,7 @@ Truemail.configuration.validation_type_for = { 'somedomain.com' => :skip }
 
 ### Added
 
-- PTR record audit, [issue details](https://github.com/rubygarage/truemail/issues/18)
+- PTR record audit, [issue details](https://github.com/truemail-rb/truemail/issues/18)
 
 ### Changed
 
@@ -541,12 +565,12 @@ Truemail.configuration.validation_type_for = { 'somedomain.com' => :skip }
 
 ### Added
 
-- MX gem logic with [RFC 7505](https://tools.ietf.org/html/rfc7505), null MX record supporting, [issue details](https://github.com/rubygarage/truemail/issues/27)
+- MX gem logic with [RFC 7505](https://tools.ietf.org/html/rfc7505), null MX record supporting, [issue details](https://github.com/truemail-rb/truemail/issues/27)
 - [Contributing guideline](CONTRIBUTING.md)
 
 ### Fixed
 
-- Multihomed MX records supporting, [issue details](https://github.com/rubygarage/truemail/issues/28)
+- Multihomed MX records supporting, [issue details](https://github.com/truemail-rb/truemail/issues/28)
 
 ### Changed
 
@@ -569,11 +593,11 @@ Truemail.configuration.validation_type_for = { 'somedomain.com' => :skip }
 
 ### Added
 
-- Checking A record presence if ```MX``` and ```CNAME``` records not exist, [issue details](https://github.com/rubygarage/truemail/issues/10)
-- Handling of ```CNAME``` records, [issue details](https://github.com/rubygarage/truemail/issues/11)
-- Checking A record if ```MX``` and ```CNAME``` records not found, [issue details](https://github.com/rubygarage/truemail/issues/12)
-- Supporting of multihomed MX records, conversion host names to ips, [issue details](https://github.com/rubygarage/truemail/issues/17)
-- Timeout configuration for DNS resolver, [issue details](https://github.com/rubygarage/truemail/issues/13)
+- Checking A record presence if ```MX``` and ```CNAME``` records not exist, [issue details](https://github.com/truemail-rb/truemail/issues/10)
+- Handling of ```CNAME``` records, [issue details](https://github.com/truemail-rb/truemail/issues/11)
+- Checking A record if ```MX``` and ```CNAME``` records not found, [issue details](https://github.com/truemail-rb/truemail/issues/12)
+- Supporting of multihomed MX records, conversion host names to ips, [issue details](https://github.com/truemail-rb/truemail/issues/17)
+- Timeout configuration for DNS resolver, [issue details](https://github.com/truemail-rb/truemail/issues/13)
 - ```.valid?``` helper
 
 ### Changed
@@ -589,12 +613,12 @@ Truemail.configuration.validation_type_for = { 'somedomain.com' => :skip }
 
 ### Fixed
 
-- Default ```REGEX_EMAIL_PATTERN```, [issue details](https://github.com/rubygarage/truemail/issues/7)
+- Default ```REGEX_EMAIL_PATTERN```, [issue details](https://github.com/truemail-rb/truemail/issues/7)
   * local part of address can't start with a dot or special symbol
   * local part of address can include ```+``` symbol
-- Default ```REGEX_DOMAIN_PATTERN```, [issue details](https://github.com/rubygarage/truemail/issues/8)
+- Default ```REGEX_DOMAIN_PATTERN```, [issue details](https://github.com/truemail-rb/truemail/issues/8)
   * TLD size increased up to 63 characters
-- Case sensitive domain names, [issue details](https://github.com/rubygarage/truemail/issues/9)
+- Case sensitive domain names, [issue details](https://github.com/truemail-rb/truemail/issues/9)
 
 ### Changed
 
@@ -641,10 +665,7 @@ Truemail.validate('email@example.com')
                 #<struct Truemail::Validate::Smtp::Response
                   port_opened=true,
                   connection=false,
-                  helo=
-                    #<Net::SMTP::Response:0x0000000002c934c8
-                    @status="250",
-                    @string="250 mx1.example.com\n">,
+                  helo=true,
                   mailfrom=false,
                   rcptto=nil,
                   errors={:mailfrom=>"554 5.7.1 Client host blocked\n", :connection=>"server dropped connection after response"}>>,]>,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (1.9.2)
+    truemail (2.0.0)
       simpleidn (~> 0.1.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![Truemail - configurable framework agnostic plain Ruby email validator](https://truemail-rb.org/assets/images/truemail_logo.png)
+# ![Truemail - configurable framework agnostic plain Ruby email validator](https://truemail-rb.org/assets/images/truemail_logo.png)
 
-[![Maintainability](https://api.codeclimate.com/v1/badges/657aa241399927dcd2e2/maintainability)](https://codeclimate.com/github/rubygarage/truemail/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/657aa241399927dcd2e2/test_coverage)](https://codeclimate.com/github/rubygarage/truemail/test_coverage) [![CircleCI](https://circleci.com/gh/rubygarage/truemail/tree/master.svg?style=svg)](https://circleci.com/gh/rubygarage/truemail/tree/master) [![Gem Version](https://badge.fury.io/rb/truemail.svg)](https://badge.fury.io/rb/truemail) [![Downloads](https://img.shields.io/gem/dt/truemail.svg?colorA=004d99&colorB=0073e6)](https://rubygems.org/gems/truemail) [![Gitter](https://badges.gitter.im/truemail-rb/community.svg)](https://gitter.im/truemail-rb/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
+[![Maintainability](https://api.codeclimate.com/v1/badges/0fea6d2e64d78d66b149/maintainability)](https://codeclimate.com/github/truemail-rb/truemail/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/0fea6d2e64d78d66b149/test_coverage)](https://codeclimate.com/github/truemail-rb/truemail/test_coverage) [![CircleCI](https://circleci.com/gh/truemail-rb/truemail/tree/develop.svg?style=svg)](https://circleci.com/gh/truemail-rb/truemail/tree/develop) [![Gem Version](https://badge.fury.io/rb/truemail.svg)](https://badge.fury.io/rb/truemail) [![Downloads](https://img.shields.io/gem/dt/truemail.svg?colorA=004d99&colorB=0073e6)](https://rubygems.org/gems/truemail) [![Gitter](https://badges.gitter.im/truemail-rb/community.svg)](https://gitter.im/truemail-rb/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
 Configurable framework agnostic plain Ruby email validator. Verify email via Regex, DNS and SMTP. Be sure that email address valid and exists.
 
@@ -127,7 +127,7 @@ You can use global gem configuration or custom independent configuration. Availa
 
 #### Setting global configuration
 
-To have an access for ```Truemail.configuration``` and gem configuration features, you must configure it first as in the example below:
+To have an access for `Truemail.configuration` and gem configuration features, you must configure it first as in the example below:
 
 ```ruby
 require 'truemail'
@@ -289,11 +289,12 @@ Please note, you should have global or custom configuration for use Truemail gem
 
 #### Whitelist/Blacklist check
 
-Whitelist/Blacklist check is zero validation level. You can define white and black list domains. It means that validation of email which contains whitelisted domain always will return ```true```, and for blacklisted domain will return ```false```.
+Whitelist/Blacklist check is zero validation level. You can define white and black list domains. It means that validation of email which contains whitelisted domain always will return `true`, and for blacklisted domain will return `false`.
 
-Please note, other validations will not processed even if it was defined in ```validation_type_for```.
+Please note, other validations will not processed even if it was defined in `validation_type_for`.
 
 **Sequence of domain list check:**
+
 1. Whitelist check
 2. Whitelist validation check
 3. Blacklist check
@@ -356,8 +357,7 @@ Truemail.configure do |config|
 end
 ```
 
-When email domain in whitelist and ```whitelist_validation``` is sets equal to ```true``` validation type will be passed to other validators.
-Validation of email which not contains whitelisted domain always will return ```false```.
+When email domain in whitelist and `whitelist_validation` is sets equal to `true` validation type will be passed to other validators. Validation of email which not contains whitelisted domain always will return `false`.
 
 ###### Email has whitelisted domain
 
@@ -459,7 +459,7 @@ Truemail.validate('email@black-domain.com')
 
 ##### Duplication case
 
-Validation result for this email returns ```true```, because it was found in whitelisted domains list first. Also ```validation_type``` for this case will be redefined.
+Validation result for this email returns `true`, because it was found in whitelisted domains list first. Also `validation_type` for this case will be redefined.
 
 ```ruby
 Truemail.validate('email@somedomain.com')
@@ -591,7 +591,7 @@ In fact it's DNS validation because it checks not MX records only. DNS validatio
 [Whitelist/Blacklist] -> [Regex validation] -> [MX validation]
 ```
 
-Please note, Truemail MX validator [not performs](https://github.com/rubygarage/truemail/issues/26) strict compliance of the [RFC 5321](https://tools.ietf.org/html/rfc5321#section-5) standard for best validation outcome.
+Please note, Truemail MX validator [not performs](https://github.com/truemail-rb/truemail/issues/26) strict compliance of the [RFC 5321](https://tools.ietf.org/html/rfc5321#section-5) standard for best validation outcome.
 
 ##### RFC MX lookup flow
 
@@ -688,13 +688,13 @@ SMTP validation is a final, third validation level. This type of validation trie
 [Whitelist/Blacklist] -> [Regex validation] -> [MX validation] -> [SMTP validation]
 ```
 
-If total count of MX servers is equal to one, ```Truemail::Smtp``` validator will use value from ```Truemail.configuration.connection_attempts``` as connection attempts. By default it's equal 2.
+If total count of MX servers is equal to one, `Truemail::Smtp` validator will use value from `Truemail.configuration.connection_attempts` as connection attempts. By default it's equal `2`.
 
 By default, you don't need pass with-parameter to use it. Example of usage is specified below:
 
 ##### SMTP safe check disabled
 
-With ```smtp_safe_check = false```
+With `smtp_safe_check = false`
 
 ```ruby
 require 'truemail'
@@ -757,10 +757,7 @@ Truemail.validate('email@example.com')
               #<struct Truemail::Validate::Smtp::Response
                 port_opened=true,
                 connection=true,
-                helo=
-                  #<Net::SMTP::Response:0x0000000002d5aca8
-                    @status="250",
-                    @string="250 127.0.1.1 Hello example.com\n">,
+                helo=true,
                 mailfrom=
                   #<Net::SMTP::Response:0x0000000002d5a618
                     @status="250",
@@ -788,7 +785,7 @@ Truemail.validate('email@example.com')
 
 ##### SMTP safe check enabled
 
-With ```smtp_safe_check = true```
+With `smtp_safe_check = true`
 
 ```ruby
 require 'truemail'
@@ -824,10 +821,7 @@ Truemail.validate('email@example.com')
               #<struct Truemail::Validate::Smtp::Response
                 port_opened=true,
                 connection=false,
-                helo=
-                  #<Net::SMTP::Response:0x0000000002c934c8
-                  @status="250",
-                  @string="250 127.0.1.1\n">,
+                helo=true,
                 mailfrom=false,
                 rcptto=nil,
                 errors={:mailfrom=>"554 5.7.1 Client host blocked\n", :connection=>"server dropped connection after response"}>>,]>,
@@ -873,10 +867,7 @@ Truemail.validate('email@example.com')
             #<struct Truemail::Validate::Smtp::Response
               port_opened=true,
               connection=true,
-              helo=
-              #<Net::SMTP::Response:0x0000000002d5aca8
-                @status="250",
-                @string="250 127.0.1.1 Hello example.com\n">,
+              helo=true,
               mailfrom=#<Net::SMTP::Response:0x0000000002d5a618 @status="250", @string="250 OK\n">,
               rcptto=false,
               errors={:rcptto=>"550 User not found\n"}>>]>,
@@ -1178,7 +1169,7 @@ All Truemail solutions: https://truemail-rb.org
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/rubygarage/truemail. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct. Please check the [open tikets](https://github.com/rubygarage/truemail/issues). Be shure to follow Contributor Code of Conduct below and our [Contributing Guidelines](CONTRIBUTING.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/truemail-rb/truemail. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct. Please check the [open tikets](https://github.com/truemail-rb/truemail/issues). Be shure to follow Contributor Code of Conduct below and our [Contributing Guidelines](CONTRIBUTING.md).
 
 ## License
 
@@ -1190,8 +1181,8 @@ Everyone interacting in the Truemail project’s codebases, issue trackers, chat
 
 ## Credits
 
-- [The Contributors](https://github.com/rubygarage/truemail/graphs/contributors) for code and awesome suggestions
-- [The Stargazers](https://github.com/rubygarage/truemail/stargazers) for showing their support
+- [The Contributors](https://github.com/truemail-rb/truemail/graphs/contributors) for code and awesome suggestions
+- [The Stargazers](https://github.com/truemail-rb/truemail/stargazers) for showing their support
 
 ## Versioning
 

--- a/lib/truemail/validate/smtp/request.rb
+++ b/lib/truemail/validate/smtp/request.rb
@@ -31,8 +31,8 @@ module Truemail
         end
 
         def run
-          session.start do |smtp_request|
-            response.connection = true
+          session.start(configuration.verifier_domain) do |smtp_request|
+            response.connection = response.helo = true
             smtp_handshakes(smtp_request, response)
           end
         rescue => error
@@ -83,7 +83,6 @@ module Truemail
 
         def session_data
           {
-            helo: configuration.verifier_domain,
             mailfrom: configuration.verifier_email,
             rcptto: email
           }

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '1.9.2'
+  VERSION = '2.0.0'
 end

--- a/truemail.gemspec
+++ b/truemail.gemspec
@@ -13,15 +13,15 @@ Gem::Specification.new do |spec|
   spec.summary       = %(truemail)
   spec.description   = %(Configurable framework agnostic plain Ruby email validator. Verify email via Regex, DNS and SMTP.)
 
-  spec.homepage      = 'https://github.com/rubygarage/truemail'
+  spec.homepage      = 'https://github.com/truemail-rb/truemail'
   spec.license       = 'MIT'
 
   spec.metadata = {
     'homepage_uri' => 'https://truemail-rb.org',
-    'changelog_uri' => 'https://github.com/rubygarage/truemail/blob/master/CHANGELOG.md',
-    'source_code_uri' => 'https://github.com/rubygarage/truemail',
+    'changelog_uri' => 'https://github.com/truemail-rb/truemail/blob/master/CHANGELOG.md',
+    'source_code_uri' => 'https://github.com/truemail-rb/truemail',
     'documentation_uri' => 'https://truemail-rb.org/truemail-gem',
-    'bug_tracker_uri' => 'https://github.com/rubygarage/truemail/issues'
+    'bug_tracker_uri' => 'https://github.com/truemail-rb/truemail/issues'
   }
 
   spec.required_ruby_version = '>= 2.5.0'


### PR DESCRIPTION
FIxed SMTP connection errors: invalid `HELO` hostname (`localhost`), duplicate `HELO` (`verifier domain`).

- [x] Updated `Truemail::Validate::Smtp::Request#run`
- [x] Updated `Truemail::Validate::Smtp::Request#session_data`
- [x] Updated behaviour of collecting `Truemail::Validate::Smtp::Response` instance
- [x] Updated CircleCI config
- [x] Updated gem version
- [x] Updated gem documentation, changelog