### PR TITLE
Feature/Collect only unique ip-addresses for target mail servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2020.11.21
+
+Collecting only unique ip-addresses for target mail servers. This update should reduce email validation time for case when remote server have closed connection via avoiding connection attempt to server with the same ip address.
+
+### Changed
+
+- Updated `Truemail::Validate::Mx#fetch_target_hosts`
+
 ## [2.0.2] - 2020.11.14
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (2.0.2)
+    truemail (2.1.0)
       simpleidn (~> 0.1.1)
 
 GEM

--- a/lib/truemail/validate/mx.rb
+++ b/lib/truemail/validate/mx.rb
@@ -30,7 +30,7 @@ module Truemail
       end
 
       def fetch_target_hosts(hosts)
-        mail_servers.push(*hosts)
+        mail_servers.push(*(hosts.uniq - mail_servers))
       end
 
       def null_mx?(domain_mx_records)

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '2.0.2'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
This update  depends on issue: #108 and feature: #109 and should reduce email validation time for case when remote server have closed connection via avoiding connection attempt to server with the same ip address.

- [x] Updated `Truemail::Validate::Mx#fetch_target_hosts`, tests
- [x] Updated changelog, gem version