### PR TITLE
Feature/SMTP fail fast

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -27,6 +27,7 @@ detectors:
     exclude:
       - Truemail::Configuration#whitelist_validation
       - Truemail::Configuration#not_rfc_mx_lookup_flow
+      - Truemail::Configuration#smtp_fail_fast
       - Truemail::Configuration#smtp_safe_check
       - Truemail::Wrapper#attempts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,35 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2020.12.01
+
+Ability to use fail fast behaviour for SMTP validation layer. When `smtp_fail_fast = true` it means that `truemail` ends smtp validation session after first attempt on the first mx server in any fail cases (network connection/timeout error, smtp validation error). This feature helps to reduce total time of SMTP validation session up to 1 second.
+
+### Added
+
+- Added `Truemail::Configuration#smtp_fail_fast`
+- Added `Truemail::Validate::Smtp#smtp_fail_fast?`
+- Added `Truemail::Validate::Smtp#filtered_mail_servers_by_fail_fast_scenario`
+
+### Changed
+
+- Updated `Truemail::Validate::Smtp#attempts`
+- Updated `Truemail::Validate::Smtp#establish_smtp_connection`
+- Updated gem documentation
+
+It's a configurable and not required option:
+
+```ruby
+Truemail.configure do |config|
+  config.smtp_fail_fast = true # by default it's equal to false
+end
+```
+
+Thanks to [@wikiti](https://github.com/wikiti) for timeout reports.
+
 ## [2.1.0] - 2020.11.21
 
-Collecting only unique ip-addresses for target mail servers. This update should reduce email validation time for case when remote server have closed connection via avoiding connection attempt to server with the same ip address.
+Collecting only unique ip-addresses for target mail servers. This update reduces email validation time for case when remote server have closed connection via avoiding connection attempt to server with the same ip address.
 
 ### Changed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (2.1.0)
+    truemail (2.2.0)
       simpleidn (~> 0.1.1)
 
 GEM

--- a/lib/truemail/configuration.rb
+++ b/lib/truemail/configuration.rb
@@ -21,7 +21,7 @@ module Truemail
                 :blacklisted_domains,
                 :logger
 
-    attr_accessor :whitelist_validation, :not_rfc_mx_lookup_flow, :smtp_safe_check
+    attr_accessor :whitelist_validation, :not_rfc_mx_lookup_flow, :smtp_fail_fast, :smtp_safe_check
 
     def initialize(&block)
       instance_initializer.each do |instace_variable, value|
@@ -102,6 +102,7 @@ module Truemail
         whitelist_validation: false,
         blacklisted_domains: [],
         not_rfc_mx_lookup_flow: false,
+        smtp_fail_fast: false,
         smtp_safe_check: false
       }
     end

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end

--- a/spec/truemail/configuration_spec.rb
+++ b/spec/truemail/configuration_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Truemail::Configuration do
       whitelist_validation
       blacklisted_domains
       not_rfc_mx_lookup_flow
+      smtp_fail_fast
       smtp_safe_check
       logger
     ].each do |attribute|
@@ -81,6 +82,7 @@ RSpec.describe Truemail::Configuration do
       expect(configuration_instance.whitelist_validation).to eq(false)
       expect(configuration_instance.blacklisted_domains).to eq([])
       expect(configuration_instance.not_rfc_mx_lookup_flow).to be(false)
+      expect(configuration_instance.smtp_fail_fast).to be(false)
       expect(configuration_instance.smtp_safe_check).to be(false)
       expect(configuration_instance.logger).to be_nil
     end
@@ -102,6 +104,7 @@ RSpec.describe Truemail::Configuration do
         expect(configuration_instance.whitelist_validation).to eq(false)
         expect(configuration_instance.blacklisted_domains).to eq([])
         expect(configuration_instance.not_rfc_mx_lookup_flow).to be(false)
+        expect(configuration_instance.smtp_fail_fast).to be(false)
         expect(configuration_instance.smtp_safe_check).to be(false)
         expect(configuration_instance.logger).to be_nil
       end
@@ -124,6 +127,7 @@ RSpec.describe Truemail::Configuration do
           .and not_change(configuration_instance, :whitelist_validation)
           .and not_change(configuration_instance, :blacklisted_domains)
           .and not_change(configuration_instance, :not_rfc_mx_lookup_flow)
+          .and not_change(configuration_instance, :smtp_fail_fast)
           .and not_change(configuration_instance, :smtp_safe_check)
           .and not_change(configuration_instance, :logger)
 
@@ -148,6 +152,7 @@ RSpec.describe Truemail::Configuration do
           .and not_change(configuration_instance, :whitelist_validation)
           .and not_change(configuration_instance, :blacklisted_domains)
           .and not_change(configuration_instance, :not_rfc_mx_lookup_flow)
+          .and not_change(configuration_instance, :smtp_fail_fast)
           .and not_change(configuration_instance, :smtp_safe_check)
           .and not_change(configuration_instance, :logger)
 
@@ -172,6 +177,7 @@ RSpec.describe Truemail::Configuration do
           .and not_change(configuration_instance, :whitelist_validation)
           .and not_change(configuration_instance, :blacklisted_domains)
           .and not_change(configuration_instance, :not_rfc_mx_lookup_flow)
+          .and not_change(configuration_instance, :smtp_fail_fast)
           .and not_change(configuration_instance, :smtp_safe_check)
           .and not_change(configuration_instance, :logger)
 
@@ -426,6 +432,14 @@ RSpec.describe Truemail::Configuration do
         it 'sets not RFC MX lookup flow' do
           expect { configuration_instance.not_rfc_mx_lookup_flow = true }
             .to change(configuration_instance, :not_rfc_mx_lookup_flow)
+            .from(false).to(true)
+        end
+      end
+
+      describe '#smtp_fail_fast=' do
+        it 'sets smtp fail fast behaviour' do
+          expect { configuration_instance.smtp_fail_fast = true }
+            .to change(configuration_instance, :smtp_fail_fast)
             .from(false).to(true)
         end
       end


### PR DESCRIPTION
Ability to use fail fast behaviour for SMTP validation layer. This PR depends on issue: #108 and feature: #112

- [x] Added `Truemail::Configuration#smtp_fail_fast`, tests
- [x] Added `Truemail::Validate::Smtp#smtp_fail_fast?`
- [x] Added `Truemail::Validate::Smtp#filtered_mail_servers_by_fail_fast_scenario`
- [x] Updated `Truemail::Validate::Smtp#establish_smtp_connection`, tests
- [x] Updated readme, changelog
- [x] Updated linter configs
- [x] Updated gem version