### PR TITLE
Technical/Remove needless timeout block

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -13,6 +13,7 @@ detectors:
       - Truemail::Validate::Smtp#run
       - Truemail::Validate::Mx#hosts_from_cname_records
       - Truemail::Configuration#logger=
+      - Truemail::Validate::Smtp::Request#initialize
 
   TooManyInstanceVariables:
     exclude:

--- a/lib/truemail/validate/smtp/request.rb
+++ b/lib/truemail/validate/smtp/request.rb
@@ -22,11 +22,10 @@ module Truemail
         end
 
         def check_port
-          Timeout.timeout(configuration.connection_timeout) do
-            return response.port_opened = !TCPSocket.new(host, Truemail::Validate::Smtp::Request::SMTP_PORT).close
-          end
+          response.port_opened =
+            Socket.tcp(host, Truemail::Validate::Smtp::Request::SMTP_PORT, connect_timeout: configuration.connection_timeout) { true }
         rescue => error
-          retry if attempts_exist? && error.is_a?(Timeout::Error)
+          retry if attempts_exist? && error.is_a?(Errno::ETIMEDOUT)
           response.port_opened = false
         end
 

--- a/spec/truemail/validate/smtp/request_spec.rb
+++ b/spec/truemail/validate/smtp/request_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe Truemail::Validate::Smtp::Request do
 
     context 'when port opened' do
       specify do
-        allow(Timeout).to receive(:timeout).with(connection_timeout).and_call_original
-        allow(TCPSocket).to receive_message_chain(:new, :close)
+        allow(Socket).to receive(:tcp).and_return(true)
         expect { request_instance.check_port }
           .to change(response_instance, :port_opened).from(nil).to(true)
       end
@@ -51,7 +50,7 @@ RSpec.describe Truemail::Validate::Smtp::Request do
 
     context 'when port closed' do
       let(:error_stubs) do
-        allow(Timeout).to receive(:timeout).with(connection_timeout).and_raise(Timeout::Error)
+        allow(Socket).to receive(:tcp).and_raise(Errno::ETIMEDOUT)
       end
 
       specify do
@@ -60,7 +59,7 @@ RSpec.describe Truemail::Validate::Smtp::Request do
       end
 
       specify do
-        allow(TCPSocket).to receive(:new).and_raise(SocketError)
+        allow(Socket).to receive(:tcp).and_raise(SocketError)
         expect { response_instance_target_method }.to change(response_instance, :port_opened).from(nil).to(false)
       end
 


### PR DESCRIPTION
# PR Details

## Description

Remove `Timeout.timeout` from `Truemail::Validate::Smtp::Request`, and replace it with native `Socket` timeout detection the same way it's done on `Truemail::Validate::Smtp::Request`.

## Related Issue

(It's a closed issue, but I propossed a change there that I though it could be usefull).

https://github.com/truemail-rb/truemail/issues/108

## Motivation and Context

Regarding [this article](http://blog.headius.com/2008/02/rubys-threadraise-threadkill-timeoutrb.html) and this [StackOverflow question](https://stackoverflow.com/questions/517219/ruby-see-if-a-port-is-open/38266150#38266150), this change includes the following two benefits:

- Stop using `Timeout.timeout` on a deep class, which may lead on the future to nested timeouts (using `Truemail::Wrapper`), which won't work.
- Use native implementations of timeout detections, which reduces system overhead by avoiding to create and destroy extra threads.

## How Has This Been Tested

Gem has been updated to match the current behaviour. Automatic tests have been updated.

The changes where tested as a monkey patch on a production environment for more than 2 months, using the main `Truemail.validate` function.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [**CONTRIBUTING** document](https://github.com/truemail-rb/truemail/blob/master/CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] I have run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I have run `rubocop` and `reek` to ensure the code style is valid
