### PR TITLE
Feature/MxBlacklist validation layer

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,7 +7,7 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-1-12
+    channel: rubocop-1-13
 
   reek:
     enabled: true

--- a/.reek.yml
+++ b/.reek.yml
@@ -34,18 +34,19 @@ detectors:
 
   UtilityFunction:
     exclude:
-      - Truemail::Validate::Smtp::Request#compose_from
+      - Truemail::Audit::Base#verifier_domain
+      - Truemail::Configuration#logger_options
+      - Truemail::Configuration#match_regex?
+      - Truemail::Configuration#regex_by_method
+      - Truemail::Dns::Worker#nameserver_port
+      - Truemail::Log::Serializer::Base#errors
+      - Truemail::Log::Serializer::ValidatorBase#replace_invalid_chars
       - Truemail::Validator#select_validation_type
+      - Truemail::Validator#constantize
       - Truemail::Validate::Base#configuration
       - Truemail::Validate::Mx#null_mx?
       - Truemail::Validate::Mx#a_record
-      - Truemail::Audit::Base#verifier_domain
-      - Truemail::Configuration#domain_matcher
-      - Truemail::Configuration#logger_options
-      - Truemail::Log::Serializer::Base#errors
-      - Truemail::Log::Serializer::ValidatorBase#replace_invalid_chars
-      - Truemail::Dns::Worker#nameserver_port
-      - Truemail::Configuration#check_dns_settings
+      - Truemail::Validate::Smtp::Request#compose_from
 
   ControlParameter:
     exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -356,6 +356,9 @@ Performance/RedundantEqualityComparisonBlock:
 Performance/RedundantSplitRegexpArgument:
   Enabled: true
 
+Performance/MapCompact:
+  Enabled: true
+
 RSpec/ExampleLength:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2021.04.28
+
+### Added
+
+- Implemented `MxBlacklist` validation. This layer provides checking mail servers with predefined blacklisted IP addresses list and can be used as a part of DEA ([disposable email address](https://en.wikipedia.org/wiki/Disposable_email_address)) validations.
+
+```ruby
+Truemail.configure do |config|
+  # Optional parameter. With this option Truemail will filter out unwanted mx servers via
+  # predefined list of ip addresses. It can be used as a part of DEA (disposable email
+  # address) validations. It is equal to empty array by default.
+  config.blacklisted_mx_ip_addresses = ['1.1.1.1', '2.2.2.2']
+end
+
+```
+
+- Added `Truemail::Validate::MxBlacklist`, tests
+
+### Changed
+
+- Updated `Truemail::Core`, tests
+- Updated `Truemail::Configuration`, tests
+- Updated `Truemail::Validator`
+- Updated `Truemail::Validate::Smtp`, tests
+- Updated `Truemail::Log::Serializer::Base`, dependent tests
+- Updated `Truemail::Log::Serializer::ValidatorText`, tests
+- Updated gem development dependencies
+- Updated gem documentation, changelog, version
+
 ## [2.3.4] - 2021.04.16
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (2.3.4)
+    truemail (2.4.0)
       simpleidn (~> 0.2.1)
 
 GEM
@@ -54,7 +54,7 @@ GEM
     public_suffix (4.0.6)
     rainbow (3.0.0)
     rake (13.0.3)
-    reek (6.0.3)
+    reek (6.0.4)
       kwalify (~> 0.7.0)
       parser (~> 3.0.0)
       psych (~> 3.1)
@@ -74,7 +74,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.12.1)
+    rubocop (1.13.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -85,10 +85,10 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
-    rubocop-performance (1.10.2)
-      rubocop (>= 0.90.0, < 2.0)
+    rubocop-performance (1.11.0)
+      rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rspec (2.2.0)
+    rubocop-rspec (2.3.0)
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
@@ -129,11 +129,11 @@ DEPENDENCIES
   overcommit (~> 0.57.0)
   pry-byebug (~> 3.9)
   rake (~> 13.0, >= 13.0.3)
-  reek (~> 6.0, >= 6.0.3)
+  reek (~> 6.0, >= 6.0.4)
   rspec (~> 3.10)
-  rubocop (~> 1.12, >= 1.12.1)
-  rubocop-performance (~> 1.10, >= 1.10.2)
-  rubocop-rspec (~> 2.2)
+  rubocop (~> 1.13)
+  rubocop-performance (~> 1.11)
+  rubocop-rspec (~> 2.3)
   simplecov (~> 0.17.1)
   truemail!
   truemail-rspec (~> 0.4)

--- a/lib/truemail/core.rb
+++ b/lib/truemail/core.rb
@@ -24,8 +24,10 @@ module Truemail
     REGEX_DOMAIN_PATTERN = /(?=\A.{4,255}\z)(\A#{REGEX_DOMAIN}\z)/.freeze
     REGEX_DOMAIN_FROM_EMAIL = /\A.+@(.+)\z/.freeze
     REGEX_SMTP_ERROR_BODY_PATTERN = /(?=.*550)(?=.*(user|account|customer|mailbox)).*/i.freeze
+    REGEX_IP_ADDRESS = /((1\d|[1-9]|2[0-4])?\d|25[0-5])(\.\g<1>){3}/.freeze
+    REGEX_IP_ADDRESS_PATTERN = /\A#{REGEX_IP_ADDRESS}\z/.freeze
     REGEX_PORT_NUMBER = /6553[0-5]|655[0-2]\d|65[0-4](\d){2}|6[0-4](\d){3}|[1-5](\d){4}|[1-9](\d){0,3}/.freeze
-    REGEX_DNS_SERVER_ADDRESS_PATTERN = /\A((1\d|[1-9]|2[0-4])?\d|25[0-5])(\.\g<1>){3}(:#{REGEX_PORT_NUMBER})?\z/.freeze
+    REGEX_DNS_SERVER_ADDRESS_PATTERN = /\A#{REGEX_IP_ADDRESS}(:#{REGEX_PORT_NUMBER})?\z/.freeze
   end
 
   module Dns
@@ -46,6 +48,7 @@ module Truemail
     require_relative '../truemail/validate/domain_list_match'
     require_relative '../truemail/validate/regex'
     require_relative '../truemail/validate/mx'
+    require_relative '../truemail/validate/mx_blacklist'
     require_relative '../truemail/validate/smtp'
     require_relative '../truemail/validate/smtp/response'
     require_relative '../truemail/validate/smtp/request'

--- a/lib/truemail/log/serializer/base.rb
+++ b/lib/truemail/log/serializer/base.rb
@@ -6,6 +6,14 @@ module Truemail
       class Base
         require 'json'
 
+        CONFIGURATION_ARRAY_ATTRS = %i[
+          validation_type_by_domain
+          whitelisted_domains
+          blacklisted_domains
+          blacklisted_mx_ip_addresses
+          dns
+        ].freeze
+        CONFIGURATION_REGEX_ATTRS = %i[email_pattern smtp_error_body_pattern].freeze
         DEFAULT_GEM_VALUE = 'default gem value'
 
         def self.call(executor_instance)
@@ -30,7 +38,7 @@ module Truemail
 
         alias warnings errors
 
-        %i[validation_type_by_domain whitelisted_domains blacklisted_domains dns].each do |method|
+        Truemail::Log::Serializer::Base::CONFIGURATION_ARRAY_ATTRS.each do |method|
           define_method(method) do
             value = executor_configuration.public_send(method)
             return if value.empty?
@@ -38,7 +46,7 @@ module Truemail
           end
         end
 
-        %i[email_pattern smtp_error_body_pattern].each do |method|
+        Truemail::Log::Serializer::Base::CONFIGURATION_REGEX_ATTRS.each do |method|
           define_method(method) do
             value = executor_configuration.public_send(method)
             default_pattern = Truemail::RegexConstant.const_get(
@@ -55,6 +63,7 @@ module Truemail
             whitelist_validation: executor_configuration.whitelist_validation,
             whitelisted_domains: whitelisted_domains,
             blacklisted_domains: blacklisted_domains,
+            blacklisted_mx_ip_addresses: blacklisted_mx_ip_addresses,
             dns: dns,
             not_rfc_mx_lookup_flow: executor_configuration.not_rfc_mx_lookup_flow,
             smtp_fail_fast: executor_configuration.smtp_fail_fast,

--- a/lib/truemail/log/serializer/validator_text.rb
+++ b/lib/truemail/log/serializer/validator_text.rb
@@ -19,9 +19,9 @@ module Truemail
         def data_composer(enumerable_object)
           enumerable_object.inject([]) do |formatted_data, (key, value)|
             data =
-              case
-              when value.is_a?(::Hash) then "\n#{printer(value)}"
-              when value.is_a?(::Array) then value.join(', ')
+              case value
+              when ::Hash then "\n#{printer(value)}"
+              when ::Array then value.join(', ')
               else value
               end
             formatted_data << "#{key.to_s.tr('_', ' ')}: #{data}".chomp << "\n"

--- a/lib/truemail/validate/mx_blacklist.rb
+++ b/lib/truemail/validate/mx_blacklist.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Truemail
+  module Validate
+    class MxBlacklist < Truemail::Validate::Base
+      ERROR = 'blacklisted mx server ip address'
+
+      def run
+        return false unless Truemail::Validate::Mx.check(result)
+        return true if success(mail_servers.none?(&blacklisted_ip?))
+        add_error(Truemail::Validate::MxBlacklist::ERROR)
+        false
+      end
+
+      private
+
+      def blacklisted_ip?
+        ->(mail_server) { configuration.blacklisted_mx_ip_addresses.include?(mail_server) }
+      end
+    end
+  end
+end

--- a/lib/truemail/validate/smtp.rb
+++ b/lib/truemail/validate/smtp.rb
@@ -13,7 +13,7 @@ module Truemail
       end
 
       def run
-        return false unless Truemail::Validate::Mx.check(result)
+        return false unless Truemail::Validate::MxBlacklist.check(result)
         establish_smtp_connection
         return true if success(success_response?)
         result.smtp_debug = smtp_results

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '2.3.4'
+  VERSION = '2.4.0'
 end

--- a/spec/support/schemas/auditor.json
+++ b/spec/support/schemas/auditor.json
@@ -17,6 +17,7 @@
               "whitelist_validation": false,
               "whitelisted_domains": null,
               "blacklisted_domains": null,
+              "blacklisted_mx_ip_addresses": null,
               "dns": null,
               "not_rfc_mx_lookup_flow": false,
               "smtp_fail_fast": false,
@@ -109,6 +110,7 @@
               "whitelist_validation",
               "whitelisted_domains",
               "blacklisted_domains",
+              "blacklisted_mx_ip_addresses",
               "dns",
               "not_rfc_mx_lookup_flow",
               "smtp_fail_fast",
@@ -156,6 +158,19 @@
                   "examples": [
                       null
                   ]
+              },
+              "blacklisted_mx_ip_addresses": {
+                "$id": "#/properties/configuration/properties/blacklisted_mx_ip_addresses",
+                "type": [
+                    "array",
+                    "null"
+                ],
+                "title": "The blacklisted mx ip addresses schema",
+                "description": "An explanation about the purpose of this instance.",
+                "default": null,
+                "examples": [
+                    null
+                ]
               },
               "dns": {
                 "$id": "#/properties/configuration/properties/dns",

--- a/spec/support/schemas/validator.json
+++ b/spec/support/schemas/validator.json
@@ -236,6 +236,7 @@
               {
                   "whitelist_validation": false,
                   "blacklisted_domains": null,
+                  "blacklisted_mx_ip_addresses": null,
                   "validation_type_by_domain": null,
                   "smtp_error_body_pattern": "default gem value",
                   "smtp_safe_check": false,
@@ -251,6 +252,7 @@
               "whitelist_validation",
               "whitelisted_domains",
               "blacklisted_domains",
+              "blacklisted_mx_ip_addresses",
               "dns",
               "not_rfc_mx_lookup_flow",
               "smtp_fail_fast",
@@ -309,6 +311,19 @@
                       null
                   ]
               },
+              "blacklisted_mx_ip_addresses": {
+                "$id": "#/properties/configuration/properties/blacklisted_mx_ip_addresses",
+                "type": [
+                    "array",
+                    "null"
+                ],
+                "title": "The blacklisted mx ip addresses schema",
+                "description": "An explanation about the purpose of this instance.",
+                "default": null,
+                "examples": [
+                    null
+                ]
+            },
               "dns": {
                 "$id": "#/properties/configuration/properties/dns",
                 "type": [

--- a/spec/truemail/configuration_spec.rb
+++ b/spec/truemail/configuration_spec.rb
@@ -42,7 +42,9 @@ RSpec.describe Truemail::Configuration do
           :response_timeout,
           :connection_attempts,
           :whitelisted_domains,
-          :blacklisted_domains
+          :blacklisted_domains,
+          :blacklisted_mx_ip_addresses,
+          :dns
         )
       end
     end
@@ -61,6 +63,7 @@ RSpec.describe Truemail::Configuration do
       whitelisted_domains
       whitelist_validation
       blacklisted_domains
+      blacklisted_mx_ip_addresses
       dns
       not_rfc_mx_lookup_flow
       smtp_fail_fast
@@ -98,6 +101,7 @@ RSpec.describe Truemail::Configuration do
       expect(configuration_instance.whitelisted_domains).to eq([])
       expect(configuration_instance.whitelist_validation).to eq(false)
       expect(configuration_instance.blacklisted_domains).to eq([])
+      expect(configuration_instance.blacklisted_mx_ip_addresses).to eq([])
       expect(configuration_instance.dns).to eq([])
       expect(configuration_instance.not_rfc_mx_lookup_flow).to be(false)
       expect(configuration_instance.smtp_fail_fast).to be(false)
@@ -121,6 +125,7 @@ RSpec.describe Truemail::Configuration do
         expect(configuration_instance.whitelisted_domains).to eq([])
         expect(configuration_instance.whitelist_validation).to eq(false)
         expect(configuration_instance.blacklisted_domains).to eq([])
+        expect(configuration_instance.blacklisted_mx_ip_addresses).to eq([])
         expect(configuration_instance.dns).to eq([])
         expect(configuration_instance.not_rfc_mx_lookup_flow).to be(false)
         expect(configuration_instance.smtp_fail_fast).to be(false)
@@ -145,6 +150,7 @@ RSpec.describe Truemail::Configuration do
           .and not_change(configuration_instance, :whitelisted_domains)
           .and not_change(configuration_instance, :whitelist_validation)
           .and not_change(configuration_instance, :blacklisted_domains)
+          .and not_change(configuration_instance, :blacklisted_mx_ip_addresses)
           .and not_change(configuration_instance, :dns)
           .and not_change(configuration_instance, :not_rfc_mx_lookup_flow)
           .and not_change(configuration_instance, :smtp_fail_fast)
@@ -171,6 +177,7 @@ RSpec.describe Truemail::Configuration do
           .and not_change(configuration_instance, :whitelisted_domains)
           .and not_change(configuration_instance, :whitelist_validation)
           .and not_change(configuration_instance, :blacklisted_domains)
+          .and not_change(configuration_instance, :blacklisted_mx_ip_addresses)
           .and not_change(configuration_instance, :dns)
           .and not_change(configuration_instance, :not_rfc_mx_lookup_flow)
           .and not_change(configuration_instance, :smtp_fail_fast)
@@ -197,6 +204,7 @@ RSpec.describe Truemail::Configuration do
           .and not_change(configuration_instance, :whitelisted_domains)
           .and not_change(configuration_instance, :whitelist_validation)
           .and not_change(configuration_instance, :blacklisted_domains)
+          .and not_change(configuration_instance, :blacklisted_mx_ip_addresses)
           .and not_change(configuration_instance, :dns)
           .and not_change(configuration_instance, :not_rfc_mx_lookup_flow)
           .and not_change(configuration_instance, :smtp_fail_fast)
@@ -439,6 +447,40 @@ RSpec.describe Truemail::Configuration do
 
           context 'with invalid whitelisted_domains= parameter context' do
             let(:invalid_argument) { ['not_domain', 123] }
+
+            include_examples 'raises extended argument error'
+          end
+        end
+      end
+
+      describe '#blacklisted_mx_ip_addresses=' do
+        let(:setter) { :blacklisted_mx_ip_addresses= }
+
+        context 'with valid blacklisted mx ip addresses parameter type and context' do
+          let(:blacklisted_mx_ip_addresses) { Array.new(2) { random_ip_address } }
+
+          it 'sets blacklisted mx ip addresses list' do
+            expect { configuration_instance.public_send(setter, blacklisted_mx_ip_addresses) }
+              .to change(configuration_instance, setter[0...-1].to_sym)
+              .from([]).to(blacklisted_mx_ip_addresses)
+          end
+        end
+
+        context 'with invalid blacklisted mx ip addresses parameter type' do
+          let(:invalid_argument) { 'not_array' }
+
+          include_examples 'raises extended argument error'
+        end
+
+        context 'with invalid blacklisted mx ip addresses parameter context' do
+          context 'when includes not a String' do
+            let(:invalid_argument) { [42, random_ip_address] }
+
+            include_examples 'raises extended argument error'
+          end
+
+          context 'when includes wrong ip address' do
+            let(:invalid_argument) { ['not_ip_address', random_ip_address] }
 
             include_examples 'raises extended argument error'
           end

--- a/spec/truemail/core_spec.rb
+++ b/spec/truemail/core_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe Truemail::RegexConstant do
     specify { expect(described_class).to be_const_defined(:REGEX_DOMAIN_PATTERN) }
     specify { expect(described_class).to be_const_defined(:REGEX_DOMAIN_FROM_EMAIL) }
     specify { expect(described_class).to be_const_defined(:REGEX_SMTP_ERROR_BODY_PATTERN) }
+    specify { expect(described_class).to be_const_defined(:REGEX_IP_ADDRESS) }
+    specify { expect(described_class).to be_const_defined(:REGEX_IP_ADDRESS_PATTERN) }
+    specify { expect(described_class).to be_const_defined(:REGEX_PORT_NUMBER) }
+    specify { expect(described_class).to be_const_defined(:REGEX_DNS_SERVER_ADDRESS_PATTERN) }
   end
 
   describe 'Truemail::RegexConstant::REGEX_EMAIL_PATTERN' do
@@ -144,6 +148,20 @@ RSpec.describe Truemail::RegexConstant do
 
     %w[user account customer mailbox].flat_map { |item| [item, item.upcase] }.each do |account_name_type|
       specify { expect(regex_pattern.match?("#{smtp_error_context} #{account_name_type}")).to be(true) }
+    end
+  end
+
+  describe 'Truemail::RegexConstant::REGEX_IP_ADDRESS_PATTERN' do
+    subject(:regex_pattern) { described_class::REGEX_IP_ADDRESS_PATTERN }
+
+    describe 'Success' do
+      specify { expect(regex_pattern.match?(random_ip_address)).to be(true) }
+    end
+
+    describe 'Failure' do
+      %w[10.300.0.256 11.287.0.1 172.1600.0.0 -0.1.1.1 8.08.8.8 192.168.0.255a 0.00.0.42].each do |invalid_ip_address|
+        specify { expect(regex_pattern.match?(invalid_ip_address)).to be(false) }
+      end
     end
   end
 
@@ -291,6 +309,7 @@ RSpec.describe Truemail::Validate do
     specify { expect(described_class).to be_const_defined(:DomainListMatch) }
     specify { expect(described_class).to be_const_defined(:Regex) }
     specify { expect(described_class).to be_const_defined(:Mx) }
+    specify { expect(described_class).to be_const_defined(:MxBlacklist) }
     specify { expect(described_class).to be_const_defined(:Smtp) }
   end
 end

--- a/spec/truemail/validate/domain_list_match_spec.rb
+++ b/spec/truemail/validate/domain_list_match_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Truemail::Validate::DomainListMatch do
   end
 
   describe '.check' do
-    subject(:list_match_validator) { described_class.check(result_instance) }
+    subject(:domain_list_match_validator) { described_class.check(result_instance) }
 
     let(:email) { random_email }
     let(:domain) { email[Truemail::RegexConstant::REGEX_DOMAIN_FROM_EMAIL, 1] }
@@ -28,7 +28,7 @@ RSpec.describe Truemail::Validate::DomainListMatch do
         specify do
           allow(configuration_instance).to receive(:whitelisted_domains).and_return([domain])
           allow(configuration_instance).to receive(:blacklisted_domains).and_return([])
-          expect { list_match_validator }.to change(result_instance, :success).from(nil).to(true)
+          expect { domain_list_match_validator }.to change(result_instance, :success).from(nil).to(true)
         end
       end
 
@@ -36,7 +36,7 @@ RSpec.describe Truemail::Validate::DomainListMatch do
         specify do
           allow(configuration_instance).to receive(:whitelisted_domains).and_return([])
           allow(configuration_instance).to receive(:blacklisted_domains).and_return([domain])
-          expect { list_match_validator }.to change(result_instance, :success)
+          expect { domain_list_match_validator }.to change(result_instance, :success)
             .from(nil).to(false)
             .and change(result_instance, :errors)
             .from({}).to(domain_list_match: Truemail::Validate::DomainListMatch::ERROR)
@@ -47,7 +47,7 @@ RSpec.describe Truemail::Validate::DomainListMatch do
         specify do
           allow(configuration_instance).to receive(:whitelisted_domains).and_return([domain])
           allow(configuration_instance).to receive(:blacklisted_domains).and_return([domain])
-          expect { list_match_validator }.to change(result_instance, :success).from(nil).to(true)
+          expect { domain_list_match_validator }.to change(result_instance, :success).from(nil).to(true)
         end
       end
 
@@ -55,7 +55,7 @@ RSpec.describe Truemail::Validate::DomainListMatch do
         specify do
           allow(configuration_instance).to receive(:whitelisted_domains).and_return([])
           allow(configuration_instance).to receive(:blacklisted_domains).and_return([])
-          expect { list_match_validator }.not_to change(result_instance, :success)
+          expect { domain_list_match_validator }.not_to change(result_instance, :success)
         end
       end
     end
@@ -69,14 +69,14 @@ RSpec.describe Truemail::Validate::DomainListMatch do
         context 'when email domain in white list' do
           specify do
             allow(configuration_instance).to receive(:blacklisted_domains).and_return([])
-            expect { list_match_validator }.not_to change(result_instance, :success)
+            expect { domain_list_match_validator }.not_to change(result_instance, :success)
           end
         end
 
         context 'when email domain exists on both lists' do
           specify do
             allow(configuration_instance).to receive(:blacklisted_domains).and_return([domain])
-            expect { list_match_validator }.to change(result_instance, :success)
+            expect { domain_list_match_validator }.to change(result_instance, :success)
               .from(nil).to(false)
               .and change(result_instance, :errors)
               .from({}).to(domain_list_match: Truemail::Validate::DomainListMatch::ERROR)
@@ -90,7 +90,7 @@ RSpec.describe Truemail::Validate::DomainListMatch do
         context 'when email domain in black list' do
           specify do
             allow(configuration_instance).to receive(:blacklisted_domains).and_return([domain])
-            expect { list_match_validator }.to change(result_instance, :success)
+            expect { domain_list_match_validator }.to change(result_instance, :success)
               .from(nil).to(false)
               .and change(result_instance, :errors)
               .from({}).to(domain_list_match: Truemail::Validate::DomainListMatch::ERROR)
@@ -100,7 +100,7 @@ RSpec.describe Truemail::Validate::DomainListMatch do
         context 'when email domain not exists on both lists' do
           specify do
             allow(configuration_instance).to receive(:blacklisted_domains).and_return([])
-            expect { list_match_validator }.to change(result_instance, :success)
+            expect { domain_list_match_validator }.to change(result_instance, :success)
               .from(nil).to(false)
               .and change(result_instance, :errors)
               .from({}).to(domain_list_match: Truemail::Validate::DomainListMatch::ERROR)

--- a/spec/truemail/validate/mx_blacklist_spec.rb
+++ b/spec/truemail/validate/mx_blacklist_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe Truemail::Validate::MxBlacklist do
+  describe 'defined constants' do
+    specify { expect(described_class).to be_const_defined(:ERROR) }
+  end
+
+  describe 'inheritance' do
+    specify { expect(described_class).to be < Truemail::Validate::Base }
+  end
+
+  describe '.check' do
+    subject(:mx_blacklist_validator) { described_class.check(result_instance) }
+
+    let(:mail_servers) { Array.new(2) { random_ip_address } }
+    let(:configuration_instance) { create_configuration(blacklisted_mx_ip_addresses: blacklisted_mx_ip_addresses) }
+    let(:validator_instance) do
+      create_validator(
+        :mx,
+        random_email,
+        mail_servers,
+        success: true,
+        configuration: configuration_instance
+      )
+    end
+    let(:result_instance) { validator_instance.result }
+
+    describe 'Success' do
+      shared_examples 'not blacklisted mx server ip address' do
+        specify { expect { mx_blacklist_validator }.not_to change(result_instance, :success) }
+      end
+
+      context 'when ip list match validation not configured' do
+        let(:configuration_instance) { create_configuration }
+
+        it_behaves_like 'not blacklisted mx server ip address'
+      end
+
+      context 'when mx servers ip addresses not included in blacklisted mx ip address list' do
+        let(:blacklisted_mx_ip_addresses) { [] }
+
+        it_behaves_like 'not blacklisted mx server ip address'
+      end
+    end
+
+    describe 'Failure' do
+      context 'when mx servers ip addresses included in blacklisted mx ip address list' do
+        let(:blacklisted_mx_ip_addresses) { mail_servers.sample(1) }
+
+        specify do
+          expect { mx_blacklist_validator }
+            .to change(result_instance, :success)
+            .from(true).to(false)
+            .and change(result_instance, :errors)
+            .from({}).to(mx_blacklist: Truemail::Validate::MxBlacklist::ERROR)
+        end
+      end
+    end
+  end
+end

--- a/spec/truemail/validate/smtp_spec.rb
+++ b/spec/truemail/validate/smtp_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Truemail::Validate::Smtp do
       described_class.new(
         Truemail::Validator::Result.new(
           email: email,
-          mail_servers: Array.new(3) { random_ip_address },
+          mail_servers: Array.new(2) { random_ip_address },
           configuration: configuration_instance
         )
       )
@@ -167,7 +167,7 @@ RSpec.describe Truemail::Validate::Smtp do
 
     describe '#run' do
       before do
-        allow(Truemail::Validate::Mx).to receive(:check).and_return(true)
+        allow(Truemail::Validate::MxBlacklist).to receive(:check).and_return(true)
         allow(result_instance.mail_servers).to receive(:each)
         result_instance.success = true
       end

--- a/truemail.gemspec
+++ b/truemail.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['admin@bestweb.com.ua']
 
   spec.summary       = %(truemail)
-  spec.description   = %(Configurable framework agnostic plain Ruby email validator. Verify email via Regex, DNS and SMTP.)
+  spec.description   = %(Configurable framework agnostic plain Ruby email validator. Verify email via Regex, DNS, SMTP and even more.)
 
   spec.homepage      = 'https://github.com/truemail-rb/truemail'
   spec.license       = 'MIT'
@@ -42,11 +42,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'overcommit', '~> 0.57.0'
   spec.add_development_dependency 'pry-byebug', '~> 3.9'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.3'
-  spec.add_development_dependency 'reek', '~> 6.0', '>= 6.0.3'
+  spec.add_development_dependency 'reek', '~> 6.0', '>= 6.0.4'
   spec.add_development_dependency 'rspec', '~> 3.10'
-  spec.add_development_dependency 'rubocop', '~> 1.12', '>= 1.12.1'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.10', '>= 1.10.2'
-  spec.add_development_dependency 'rubocop-rspec', '~> 2.2'
+  spec.add_development_dependency 'rubocop', '~> 1.13'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.11'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.3'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'truemail-rspec', '~> 0.4'
   spec.add_development_dependency 'webmock', '~> 3.12', '>= 3.12.2'


### PR DESCRIPTION
This layer provides checking extracted mail server(s) IP address from MX validation with predefined blacklisted IP addresses list. It can be used as a part of DEA ([disposable email address](https://en.wikipedia.org/wiki/Disposable_email_address)) validations.

```code
[Whitelist/Blacklist] -> [Regex validation] -> [MX validation] -> [MX blacklist validation]
```

Example of usage:

```ruby
require 'truemail'

Truemail.configure do |config|
  config.verifier_email = 'verifier@example.com'
  config.blacklisted_mx_ip_addresses = ['127.0.1.2']
end

Truemail.validate('email@example.com', with: :mx_blacklist)

=> #<Truemail::Validator:0x00007fca0c8aea70
 @result=
  #<struct Truemail::Validator::Result
   success=false,
   email="email@example.com",
   domain="example.com",
   mail_servers=["127.0.1.1", "127.0.1.2"],
   errors={:mx_blacklist=>"blacklisted mx server ip address"},
   smtp_debug=nil,
   configuration=
    #<Truemail::Configuration:0x00007fca0c8aeb38
     @blacklisted_domains=[],
     @blacklisted_mx_ip_addresses=["127.0.1.2"],
     @connection_attempts=2,
     @connection_timeout=2,
     @default_validation_type=:smtp,
     @dns=[],
     @email_pattern=/(?=\A.{6,255}\z)(\A([\p{L}0-9]+[\w|\-.+]*)@((?i-mx:[\p{L}0-9]+([\-.]{1}[\p{L}0-9]+)*\.\p{L}{2,63}))\z)/,
     @not_rfc_mx_lookup_flow=false,
     @response_timeout=2,
     @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
     @smtp_fail_fast=false,
     @smtp_safe_check=false,
     @validation_type_by_domain={},
     @verifier_domain="example.com",
     @verifier_email="verifier@example.com",
     @whitelist_validation=false,
     @whitelisted_domains=[]>>,
 @validation_type=:mx_blacklist>
```
- [x] Added `Truemail::Validate::MxBlacklist`, tests
- [x] Updated `Truemail::Core`, tests
- [x] Updated `Truemail::Configuration`, tests
- [x] Updated `Truemail::Validator`
- [x] Updated `Truemail::Validate::Smtp`, tests
- [x] Updated `Truemail::Log::Serializer::Base`, dependent tests
- [x] Updated `Truemail::Log::Serializer::ValidatorText`, tests
- [x] Updated gem development dependencies
- [x] Updated gem documentation, changelog, version