### PR TITLE
Technical/Update default regex email pattern

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,7 +7,7 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-1-16
+    channel: rubocop-1-18
 
   reek:
     enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,9 @@ Naming/VariableNumber:
 Naming/RescuedExceptionsVariableName:
   Enabled: false
 
+Naming/InclusiveLanguage:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 
@@ -195,6 +198,9 @@ Layout/BeginEndAlignment:
   Enabled: true
 
 Layout/SpaceBeforeBrackets:
+  Enabled: true
+
+Layout/LineEndStringConcatenationIndentation:
   Enabled: true
 
 Lint/NonDeterministicRequireOrder:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.4] - 2021.06.29
+
+### Updated
+
+Allowed using special characters in email user names (following [RFC 3696](https://datatracker.ietf.org/doc/html/rfc3696#page-6)) for default regex email pattern.
+
+- Updated `Truemail::RegexConstant::REGEX_EMAIL_PATTERN`, tests
+- Updated gem development dependencies
+- Updated Rubocop/Codeclimate config
+- Updated gem documentation, version
+
 ## [2.4.3] - 2021.06.15
 
 ### Updated

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (2.4.3)
+    truemail (2.4.4)
       simpleidn (~> 0.2.1)
 
 GEM
@@ -75,7 +75,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.16.1)
+    rubocop (1.18.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -121,7 +121,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
-  bundler (~> 2.2, >= 2.2.20)
+  bundler (~> 2.2, >= 2.2.21)
   bundler-audit (~> 0.8.0)
   dns_mock (~> 1.3)
   faker (~> 2.18)
@@ -132,7 +132,7 @@ DEPENDENCIES
   rake (~> 13.0, >= 13.0.3)
   reek (~> 6.0, >= 6.0.4)
   rspec (~> 3.10)
-  rubocop (~> 1.16, >= 1.16.1)
+  rubocop (~> 1.18)
   rubocop-performance (~> 1.11, >= 1.11.3)
   rubocop-rspec (~> 2.4)
   simplecov (~> 0.17.1)
@@ -141,4 +141,4 @@ DEPENDENCIES
   webmock (~> 3.13)
 
 BUNDLED WITH
-   2.2.20
+   2.2.21

--- a/lib/truemail/core.rb
+++ b/lib/truemail/core.rb
@@ -20,7 +20,7 @@ module Truemail
 
   module RegexConstant
     REGEX_DOMAIN = /[\p{L}0-9]+([\-.]{1}[\p{L}0-9]+)*\.\p{L}{2,63}/i.freeze
-    REGEX_EMAIL_PATTERN = /(?=\A.{6,255}\z)(\A([\p{L}0-9]+[\w|\-.+]*)@(#{REGEX_DOMAIN})\z)/.freeze
+    REGEX_EMAIL_PATTERN = /(?=\A.{6,255}\z)(\A([\p{L}0-9]+[\W\w]*)@(#{REGEX_DOMAIN})\z)/.freeze
     REGEX_DOMAIN_PATTERN = /(?=\A.{4,255}\z)(\A#{REGEX_DOMAIN}\z)/.freeze
     REGEX_DOMAIN_FROM_EMAIL = /\A.+@(.+)\z/.freeze
     REGEX_SMTP_ERROR_BODY_PATTERN = /(?=.*550)(?=.*(user|account|customer|mailbox)).*/i.freeze

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '2.4.3'
+  VERSION = '2.4.4'
 end

--- a/spec/truemail/core_spec.rb
+++ b/spec/truemail/core_spec.rb
@@ -65,20 +65,28 @@ RSpec.describe Truemail::RegexConstant do
       end
     end
 
-    it 'not allows special chars' do
+    it 'allows special chars' do
       expect(
-        regex_pattern.match?(Truemail::GenerateEmailHelper.call(invalid_email_with: %w[! ~ , ' & %]))
-      ).to be(false)
+        regex_pattern.match?(Truemail::GenerateEmailHelper.call(symbols: %w[- _ . + ! ~ , ' & % # $ * / = ? ^ ` { | }]))
+      ).to be(true)
     end
 
-    it "not allows '-', '_', '.', '+' for one char username" do
+    it 'not allows special chars for one char username' do
       expect(
-        regex_pattern.match?(Truemail::GenerateEmailHelper.call(size: :min, invalid_email_with: %w[- _ . +]))
+        regex_pattern.match?(
+          Truemail::GenerateEmailHelper.call(size: :min, invalid_email_with: %w[- _ . + ! ~ , ' & % # $ * / = ? ^ ` { | }])
+        )
       ).to be(false)
     end
 
     it 'allows not ascii chars in user and domain' do
       %w[niña@mañana.cØm квіточка@пошта.укр user@納豆.jp].each do |email_example|
+        expect(regex_pattern.match?(email_example)).to be(true)
+      end
+    end
+
+    it 'allows not ascii chars in user and domain with special characters in user name' do
+      %w[niña+mañana@mañana.cØm квіточка!@пошта.укр user~Admin@納豆.jp].each do |email_example|
         expect(regex_pattern.match?(email_example)).to be(true)
       end
     end

--- a/truemail.gemspec
+++ b/truemail.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'simpleidn', '~> 0.2.1'
 
-  spec.add_development_dependency 'bundler', '~> 2.2', '>= 2.2.20'
+  spec.add_development_dependency 'bundler', '~> 2.2', '>= 2.2.21'
   spec.add_development_dependency 'bundler-audit', '~> 0.8.0'
   spec.add_development_dependency 'dns_mock', '~> 1.3'
   spec.add_development_dependency 'faker', '~> 2.18'
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.3'
   spec.add_development_dependency 'reek', '~> 6.0', '>= 6.0.4'
   spec.add_development_dependency 'rspec', '~> 3.10'
-  spec.add_development_dependency 'rubocop', '~> 1.16', '>= 1.16.1'
+  spec.add_development_dependency 'rubocop', '~> 1.18'
   spec.add_development_dependency 'rubocop-performance', '~> 1.11', '>= 1.11.3'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.4'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'


### PR DESCRIPTION
Following to [RFC 3696](https://datatracker.ietf.org/doc/html/rfc3696#page-6) updated default regex email pattern.

- [x] Updated `Truemail::RegexConstant::REGEX_EMAIL_PATTERN`, tests
- [x] Updated gem development dependencies
- [x] Updated Rubocop/Codeclimate config
- [x] Updated gem version, changelog