### PR TITLE
Bugfix/Wrong domain punycode extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.6] - 2021.07.10
+
+### Fixed
+
+- Wrong domain punycode extraction in DNS validation layer
+
+### Updated
+
+- Updated gem codebase, restored `Truemail::RegexConstant::REGEX_DOMAIN_FROM_EMAIL`
+- Updated tests
+
 ## [2.4.5] - 2021.07.09
 
 ### Removed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (2.4.5)
+    truemail (2.4.6)
       simpleidn (~> 0.2.1)
 
 GEM

--- a/lib/truemail/core.rb
+++ b/lib/truemail/core.rb
@@ -22,6 +22,7 @@ module Truemail
     REGEX_DOMAIN = /[\p{L}0-9]+([\-.]{1}[\p{L}0-9]+)*\.\p{L}{2,63}/i.freeze
     REGEX_EMAIL_PATTERN = /(?=\A.{6,255}\z)(\A([\p{L}0-9]+[\W\w]*)@(#{REGEX_DOMAIN})\z)/.freeze
     REGEX_DOMAIN_PATTERN = /(?=\A.{4,255}\z)(\A#{REGEX_DOMAIN}\z)/.freeze
+    REGEX_DOMAIN_FROM_EMAIL = /\A.+@(.+)\z/.freeze
     REGEX_SMTP_ERROR_BODY_PATTERN = /(?=.*550)(?=.*(user|account|customer|mailbox)).*/i.freeze
     REGEX_IP_ADDRESS = /((1\d|[1-9]|2[0-4])?\d|25[0-5])(\.\g<1>){3}/.freeze
     REGEX_IP_ADDRESS_PATTERN = /\A#{REGEX_IP_ADDRESS}\z/.freeze

--- a/lib/truemail/validate/domain_list_match.rb
+++ b/lib/truemail/validate/domain_list_match.rb
@@ -15,7 +15,7 @@ module Truemail
       private
 
       def email_domain
-        @email_domain ||= result.email[Truemail::RegexConstant::REGEX_EMAIL_PATTERN, 3]
+        @email_domain ||= result.email[Truemail::RegexConstant::REGEX_DOMAIN_FROM_EMAIL, 1]
       end
 
       def whitelisted_domain?

--- a/lib/truemail/validate/mx.rb
+++ b/lib/truemail/validate/mx.rb
@@ -53,8 +53,8 @@ module Truemail
 
       def domain
         @domain ||= begin
-          result.domain = result.email[Truemail::RegexConstant::REGEX_EMAIL_PATTERN, 3]
-          result.punycode_email[Truemail::RegexConstant::REGEX_EMAIL_PATTERN, 3]
+          result.domain = result.email[Truemail::RegexConstant::REGEX_DOMAIN_FROM_EMAIL, 1]
+          result.punycode_email[Truemail::RegexConstant::REGEX_DOMAIN_FROM_EMAIL, 1]
         end
       end
 

--- a/lib/truemail/validate/smtp/request.rb
+++ b/lib/truemail/validate/smtp/request.rb
@@ -50,7 +50,7 @@ module Truemail
           REQUEST_PARAMS = %i[connection_timeout response_timeout verifier_domain verifier_email].freeze
 
           def initialize(configuration)
-            REQUEST_PARAMS.each do |attribute|
+            Truemail::Validate::Smtp::Request::Configuration::REQUEST_PARAMS.each do |attribute|
               self.class.class_eval { attr_reader attribute }
               instance_variable_set(:"@#{attribute}", configuration.public_send(attribute))
             end

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '2.4.5'
+  VERSION = '2.4.6'
 end

--- a/spec/support/helpers/context_helper.rb
+++ b/spec/support/helpers/context_helper.rb
@@ -2,8 +2,14 @@
 
 module Truemail
   module ContextHelper
+    ASCII_WORDS = %w[mañana ĉapelo dấu παράδειγμα 買@屋企].freeze
+
     def random_email
       faker.email
+    end
+
+    def random_internationalized_email
+      "#{faker.username}@#{Truemail::ContextHelper::ASCII_WORDS.sample}.#{faker.domain_suffix}"
     end
 
     def random_ip_address
@@ -20,6 +26,14 @@ module Truemail
 
     def rdns_lookup_host_address(host_address)
       host_address.gsub(/(\d+).(\d+).(\d+).(\d+)/, '\4.\3.\2.\1.in-addr.arpa')
+    end
+
+    def domain_from_email(email)
+      email[Truemail::RegexConstant::REGEX_DOMAIN_FROM_EMAIL, 1]
+    end
+
+    def email_punycode_domain(email)
+      Truemail::Dns::PunycodeRepresenter.call(email)[Truemail::RegexConstant::REGEX_DOMAIN_FROM_EMAIL, 1]
     end
 
     private

--- a/spec/support/helpers/context_helper_spec.rb
+++ b/spec/support/helpers/context_helper_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Truemail::ContextHelper, type: :helper do # rubocop:disable RSpec/FilePath
+  describe 'defined constants' do
+    specify { expect(described_class).to be_const_defined(:ASCII_WORDS) }
+  end
+
   describe '#random_email' do
     specify do
       expect(Faker::Internet).to receive(:email).and_call_original
@@ -34,6 +38,36 @@ RSpec.describe Truemail::ContextHelper, type: :helper do # rubocop:disable RSpec
   describe '#rdns_lookup_host_address' do
     specify do
       expect(rdns_lookup_host_address('10.20.30.40')).to eq('40.30.20.10.in-addr.arpa')
+    end
+  end
+
+  describe '#domain_from_email' do
+    let(:domain) { 'domain' }
+    let(:email) { "user@#{domain}" }
+
+    specify { expect(domain_from_email(email)).to eq(domain) }
+  end
+
+  describe '#email_punycode_domain' do
+    let(:domain) { 'mañana.cøm' }
+    let(:email) { "user@#{domain}" }
+
+    specify do
+      expect(Truemail::Dns::PunycodeRepresenter).to receive(:call).with(email).and_call_original
+      expect(email_punycode_domain(email)).to eq('xn--maana-pta.xn--cm-lka')
+    end
+  end
+
+  describe '#random_internationalized_email' do
+    let(:user) { 'user' }
+    let(:domain_zone) { 'com' }
+    let(:ascii_word) { 'mañana' }
+
+    specify do
+      stub_const("#{described_class}::ASCII_WORDS", [ascii_word])
+      expect(Faker::Internet).to receive(:username).and_return(user)
+      expect(Faker::Internet).to receive(:domain_suffix).and_return(domain_zone)
+      expect(random_internationalized_email).to eq("#{user}@#{ascii_word}.#{domain_zone}")
     end
   end
 end

--- a/spec/truemail/core_spec.rb
+++ b/spec/truemail/core_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Truemail::RegexConstant do
     specify { expect(described_class).to be_const_defined(:REGEX_DOMAIN) }
     specify { expect(described_class).to be_const_defined(:REGEX_EMAIL_PATTERN) }
     specify { expect(described_class).to be_const_defined(:REGEX_DOMAIN_PATTERN) }
+    specify { expect(described_class).to be_const_defined(:REGEX_DOMAIN_FROM_EMAIL) }
     specify { expect(described_class).to be_const_defined(:REGEX_SMTP_ERROR_BODY_PATTERN) }
     specify { expect(described_class).to be_const_defined(:REGEX_IP_ADDRESS) }
     specify { expect(described_class).to be_const_defined(:REGEX_IP_ADDRESS_PATTERN) }
@@ -137,6 +138,15 @@ RSpec.describe Truemail::RegexConstant do
         expect(regex_pattern.match?(domain)).to be(true)
       end
     end
+  end
+
+  describe 'Truemail::RegexConstant::REGEX_DOMAIN_FROM_EMAIL' do
+    subject(:regex_pattern) { described_class::REGEX_DOMAIN_FROM_EMAIL }
+
+    let(:email) { 'i@domain' }
+
+    specify { expect(regex_pattern.match?(email)).to be(true) }
+    specify { expect(email[regex_pattern, 1]).to eq('domain') }
   end
 
   describe 'Truemail::RegexConstant::REGEX_SMTP_ERROR_BODY_PATTERN' do

--- a/spec/truemail/log/serializer/validator_text_spec.rb
+++ b/spec/truemail/log/serializer/validator_text_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Truemail::Log::Serializer::ValidatorText do
 
             CONFIGURATION SETTINGS:
             whitelist validation: false
-            whitelisted domains: #{email[Truemail::RegexConstant::REGEX_EMAIL_PATTERN, 3]}
+            whitelisted domains: #{domain_from_email(email)}
             not rfc mx lookup flow: false
             smtp fail fast: false
             smtp safe check: false
@@ -110,7 +110,7 @@ RSpec.describe Truemail::Log::Serializer::ValidatorText do
 
             CONFIGURATION SETTINGS:
             whitelist validation: false
-            blacklisted domains: #{email[Truemail::RegexConstant::REGEX_EMAIL_PATTERN, 3]}
+            blacklisted domains: #{domain_from_email(email)}
             not rfc mx lookup flow: false
             smtp fail fast: false
             smtp safe check: false

--- a/spec/truemail/validate/domain_list_match_spec.rb
+++ b/spec/truemail/validate/domain_list_match_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Truemail::Validate::DomainListMatch do
     subject(:domain_list_match_validator) { described_class.check(result_instance) }
 
     let(:email) { random_email }
-    let(:domain) { email[Truemail::RegexConstant::REGEX_EMAIL_PATTERN, 3] }
+    let(:domain) { domain_from_email(email) }
     let(:configuration_instance) { create_configuration }
     let(:result_instance) { Truemail::Validator::Result.new(email: email, configuration: configuration_instance) }
 


### PR DESCRIPTION
Bugfix for https://github.com/truemail-rb/truemail/issues/164:

- [x] Fixed wrong domain punycode extraction in DNS validation layer
- [x] Restored `Truemail::RegexConstant::REGEX_DOMAIN_FROM_EMAIL`, tests
- [x] Updated gem codebase/tests
- [x] Updated gem version