### PR TITLE
Feature/Reduce DNS requests for invalid email domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2021.09.01
+
+### Updated
+
+Optimized DNS (MX) validation flow. Removed needless DNS request for case when custom email pattern was defined and email for validation includes invalid domain name.
+
+- Updated `Truemail::Validate::Mx#run`, tests
+- Updated gem development dependencies
+- Updated gem documentation, version
+
 ## [2.4.9] - 2021.08.20
 
 ### Updated

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (2.4.9)
+    truemail (2.5.0)
       simpleidn (~> 0.2.1)
 
 GEM

--- a/lib/truemail/validate/mx.rb
+++ b/lib/truemail/validate/mx.rb
@@ -8,12 +8,16 @@ module Truemail
 
       def run
         return false unless Truemail::Validate::Regex.check(result)
-        return true if success(mx_lookup && domain_not_include_null_mx)
+        return true if success(email_domain_valid? && mx_lookup && domain_not_include_null_mx)
         mail_servers.clear && add_error(Truemail::Validate::Mx::ERROR)
         false
       end
 
       private
+
+      def email_domain_valid?
+        Truemail::RegexConstant::REGEX_DOMAIN_PATTERN.match?(result.domain)
+      end
 
       def host_extractor_methods
         return %i[hosts_from_mx_records?] if configuration.not_rfc_mx_lookup_flow

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '2.4.9'
+  VERSION = '2.5.0'
 end


### PR DESCRIPTION
 - [x] Updated `Truemail::Validate::Mx#run`, tests
 - [x] Updated gem development dependencies
 - [x] Updated gem documentation, changelog, version